### PR TITLE
Add the game's Node SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "node-traffic-controller",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "auto-traffic-control": "file:../auto-traffic-control/sdk/node"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
@@ -19,6 +22,19 @@
         "prettier": "2.6.2",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3"
+      }
+    },
+    "../auto-traffic-control/sdk/node": {
+      "version": "0.3.0-alpha.2",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "google-protobuf": "^3.20.1-rc.1"
+      },
+      "devDependencies": {
+        "typescript": "^4.6.3"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "^1.6.6"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -465,6 +481,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/auto-traffic-control": {
+      "resolved": "../auto-traffic-control/sdk/node",
+      "link": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2902,6 +2922,13 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "auto-traffic-control": {
+      "version": "file:../auto-traffic-control/sdk/node",
+      "requires": {
+        "google-protobuf": "^3.20.1-rc.1",
+        "typescript": "^4.6.3"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "prettier": "2.6.2",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3"
+  },
+  "dependencies": {
+    "auto-traffic-control": "file:../auto-traffic-control/sdk/node"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,41 @@
+import {
+  getCredentials,
+  AtcServiceClient,
+  GetVersionRequest,
+  GetVersionResponse,
+} from "auto-traffic-control";
+
 function main() {
-  console.log("Hello, World!");
+  const atcService = new AtcServiceClient("localhost:4747", getCredentials());
+
+  atcService.getVersion(
+    new GetVersionRequest(),
+    (err, response: GetVersionResponse) => {
+      if (err != null) {
+        throw err;
+      }
+
+      const version = response.getVersion();
+
+      if (version != null) {
+        let versionString = [
+          version.getMajor(),
+          version.getMinor(),
+          version.getPatch(),
+        ].join(".");
+
+        if (version.getPre() !== "") {
+          versionString = versionString.concat(version.getPre());
+        }
+
+        console.log(
+          `Auto Traffic Control is running version '${versionString}'`
+        );
+      } else {
+        throw new Error("Requesting the version returned an empty response.");
+      }
+    }
+  );
 }
 
 main();


### PR DESCRIPTION
The game's SDK for the Node ecosystem has been added as a dependency, and the example from the game's repository [^1] has been copied into the project as a proof-of-concept.

[^1]: https://github.com/jdno/auto-traffic-control