### PR TITLE
Update Prettier jobs

### DIFF
--- a/.github/workflows/push-json.yml
+++ b/.github/workflows/push-json.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           dry: true
           prettier_options: "--check **/*.json"

--- a/.github/workflows/push-markdown.yml
+++ b/.github/workflows/push-markdown.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           dry: true
           prettier_options: "--check **/*.md"

--- a/.github/workflows/push-yaml.yml
+++ b/.github/workflows/push-yaml.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           dry: true
           prettier_options: "--check **/*.{yml,yaml}"


### PR DESCRIPTION
The jobs that run Prettier have been upgraded to the latest version of the workflow. This was necessary, since the previous version was broken and failed to run.